### PR TITLE
Add start/end gcode for Klicky for Auto-Z Calibration

### DIFF
--- a/autoz.cfg
+++ b/autoz.cfg
@@ -17,6 +17,9 @@ probing_second_speed: 5
 probing_retract_dist: 2
 probing_first_fast: true
 
+start_gcode: Dock_Probe_Unlock
+before_switch_gcode: Attach_Probe
+end_gcode: Dock_Probe
 
 [gcode_macro CALIBRATE_Z]
 rename_existing: BASE_CALIBRATE_Z


### PR DESCRIPTION
Added missing start/end gcode for Klicky probe docking/undocking when using auto-z.

These options let you:
- Dock the Klicky if it's attached at the start of the calibration
- Attach the Klicky after the nozzle probe
- Dock the Klicky after calibration completes